### PR TITLE
修复由于验证会修改rules信息、导致表格会再次请求问题

### DIFF
--- a/src/components/ma-crud/components/form.vue
+++ b/src/components/ma-crud/components/form.vue
@@ -764,14 +764,29 @@ const formItemReadonly = (item) => {
   }
   return false
 }
+
+const toRules = (rules) => {
+
+  if (!rules) {
+    return []
+  }
+
+  if (Array.isArray(rules)) {
+    return rules.map(v => ({...v}))
+  }
+
+  return {...rules}
+}
+
 const getRules = (item) => {
   if (currentAction.value === 'add') {
-    return item.addRules ? item.addRules : item.rules || []
+    return toRules(item.addRules ? item.addRules : item.rules || [])
   }
   if (currentAction.value === 'edit') {
-    return item.editRules ? item.editRules : item.rules || []
+    return toRules(item.editRules ? item.editRules : item.rules || [])
   }
 }
+
 const getComponent = (item) => {
   if (! item.formType) {
     return `a-input`


### PR DESCRIPTION
问题描述：

创建或者编辑表单，并且表单存在验证规则，对表单的操作会造成表格会自动刷新一次

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/11523869/196720511-ed7f4cbb-f38a-42c7-94e1-a9248d6e7ebc.png">

通过调试工具查看、是因为执行了验证，验证会修改传递给 a-form-item 中rules 属性信息，从而导致表格会刷新一次

<img width="1116" alt="image" src="https://user-images.githubusercontent.com/11523869/196721855-76b5abd5-4699-49c0-892e-fd717844a88b.png">

修复方式:

将传递给a-form-item 中 rules 属性信息重新生成一个新的对象、防止传递引用
