### PR TITLE
feat:增加后台有新版本提示版本升级

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN yarn install && \
     if [ "$NODE_ENV" = "production" ]; then yarn build --mode production; fi && \
     yarn cache clean
 
+RUN yarn generate:version
+
 FROM nginx:alpine
 
 COPY --from=build /opt/www/dist /usr/share/nginx/html

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "mineadmin-vue",
+  "admin_name": "mineadmin-vue",
   "version": "1.3.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite serve --mode development",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "generate:version": "generate-version-file dist public"
   },
   "dependencies": {
     "vite": "^4.3.3",
@@ -37,7 +39,8 @@
     "vue-echarts": "^6.0.2",
     "vue-i18n": "^9.1.10",
     "vue-router": "^4.1.6",
-    "vuedraggable": "^4.1.0"
+    "vuedraggable": "^4.1.0",
+    "version-rocket": "^1.6.2"
   },
   "devDependencies": {
     "less": "^4.1.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,12 +8,26 @@
  - @Link   https://gitee.com/xmo/mineadmin-vue
 -->
 <script setup>
+  import { checkVersion } from 'version-rocket'
+  import { version,admin_name } from '../package.json'
   import cn from '@arco-design/web-vue/es/locale/lang/zh-cn'
   import en from '@arco-design/web-vue/es/locale/lang/en-us'
   import { ref } from 'vue'
   import { useAppStore } from './store'
   const appStore = useAppStore()
   const lang = ref(appStore.language === 'zh_CN' ? cn : en)
+
+
+  checkVersion({
+      localPackageVersion: version,
+      originVersionFileUrl: `${location.origin}/version.json`,
+      // 更多配置选项请参考 API
+  },{
+      title:admin_name,
+      description:"有新版本更新",
+      buttonText:"立即更新",
+      // cancelButtonText:"稍后更新",
+  })
 </script>
 
 <template>


### PR DESCRIPTION
效果展示

<img width="464" alt="image" src="https://github.com/kanyxmo/MineAdmin-Vue/assets/30717763/b543fc5b-a468-4422-bf50-b7fbc9532c1c">

[扩展地址](https://github.com/guMcrey/version-rocket/blob/main/README.zh-CN.md)
# 使用方式
当后台发布新版本后，修改 `package.json`中`version`号打包发行,该包会定时请求静态接口去对比版本号是否弹出右下角窗口升级。


# 注意
 `package.json`中`name`设置为中文会提示警告，所以增加了个`admin_name`。

  如果使用`Dockfile`打包镜像则自动运行`RUN yarn generate:version`生成版本文件在项目中,传统本地打包请在打包后运行` yarn generate:version`生成版本对比文件。

# 不足
在`App.vue`中应该把这些调用翻译来完成，但对多语言了解不多，需要其他人来搞一下
<img width="1118" alt="image" src="https://github.com/kanyxmo/MineAdmin-Vue/assets/30717763/ca24b681-c734-4dba-8f39-3cf980f1c1ec">

