### PR TITLE
优化curd弹出层手机端显示全屏 form-modal组件

### DIFF
--- a/src/components/ma-crud/components/form.vue
+++ b/src/components/ma-crud/components/form.vue
@@ -56,7 +56,10 @@ const dataLoading = ref(true)
 const emit = defineEmits(['success', 'error'])
 
 provide('form', toRaw(form))
-
+if (window.screen.width < 768) {
+  options.formOption.width = window.screen.width
+  options.formOption.isFull = true
+}
 const submit = async () => {
   const formData = maFormRef.value.getFormData()
   if (await maFormRef.value.validateForm()) {

--- a/src/components/ma-form-modal/index.vue
+++ b/src/components/ma-form-modal/index.vue
@@ -51,6 +51,14 @@ const prop = defineProps({
   submit: { type: Function, default: () => {} },
 })
 
+if (window.screen.width < 768) {
+  options.formOption.width = window.screen.width
+  options.formOption.isFull = true
+}
+
+formColumns.value = [...prop.column, ...prop.columns]
+let submitEvent = prop.submit
+
 const maFormRef = ref()
 
 const modal = reactive({

--- a/src/components/ma-form-modal/index.vue
+++ b/src/components/ma-form-modal/index.vue
@@ -1,5 +1,7 @@
 <template>
   <a-modal
+    :width="prop.width"
+    :fullscreen="isFull"
     v-model:visible="modal.visible"
     :on-before-ok="modal.submit"
     unmount-on-close
@@ -36,11 +38,14 @@ import { reactive, ref, watch } from "vue"
 import MaForm from "@/components/ma-form/index.vue"
 import {Message} from "@arco-design/web-vue"
 import MaInfo from "@/components/ma-info/index.vue"
+import {setModalSizeEvent} from "@/utils/common";
 
 const emit = defineEmits(["visible", "validateError", "open", "cancel", "close"])
 const form = ref({})
 const formColumns = ref([])
 const prop = defineProps({
+  width: {type: Number, default: 1200}, // modal框大小
+  isFull: { type: Boolean, default: false,}, // 是否全屏
   title: { type: String, default: "" }, // 弹出框标题
   column: { type: Array, default: []}, // ma-form字段
   columns: {type: Array, default: []}, // ma-form字段 别名
@@ -51,10 +56,10 @@ const prop = defineProps({
   submit: { type: Function, default: () => {} },
 })
 
-if (window.screen.width < 768) {
-  options.formOption.width = window.screen.width
-  options.formOption.isFull = true
-}
+const isFull = ref(prop.isFull)
+setModalSizeEvent((config) => {
+  isFull.value = config.isFull
+})
 
 formColumns.value = [...prop.column, ...prop.columns]
 let submitEvent = prop.submit

--- a/src/components/ma-info-modal/index.vue
+++ b/src/components/ma-info-modal/index.vue
@@ -1,6 +1,7 @@
 <template>
   <a-modal
       :width="prop.width"
+      :fullscreen="isFull"
       v-model:visible="modal.visible"
       :on-before-ok="modal.submit"
       :unmount-on-close="true"
@@ -9,6 +10,7 @@
     <template #title>
       {{ prop.title }}
     </template>
+    <slot></slot>
     <slot name="body"></slot>
     <a-card
         class="mt-2"
@@ -48,11 +50,13 @@ import MaInfo from "../ma-info/index.vue";
 import {getCurrentInstance, reactive, ref, watch} from "vue";
 import {isArray, isFunction, isObject, isString} from "lodash";
 import {isComponent} from "@arco-design/web-vue/es/_utils/vue-utils";
+import {setModalSizeEvent} from "@/utils/common";
 const emit = defineEmits(["visible", "validateError", "open", "cancel", "close"]);
 const app = getCurrentInstance().appContext.app
 const maFormRef = ref()
 const prop = defineProps({
   width: {type: Number, default: 1200}, // modal框大小
+  isFull: { type: Boolean, default: false},
   title: { type: String, default: "" }, // 弹出框标题
   column: { type: Array, default: [] }, // ma-form字段
   default_visible: { type: Boolean, default: false}, // 默认隐藏
@@ -62,6 +66,11 @@ const prop = defineProps({
   formOptions: {type: Object, default: {}}, // ma-form-options
   formColumns: { type: Array, default: []}
 });
+const isFull = ref(prop.isFull)
+setModalSizeEvent((config) => {
+  isFull.value = config.isFull
+})
+
 const maInfoRefs = ref([])
 const layout = ref([])
 const infoData = ref({})
@@ -128,6 +137,7 @@ const modal = reactive({
 });
 
 init()
+
 defineExpose({
   open: modal.open,
   close: modal.close,

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -197,6 +197,10 @@ export const formatJson = (jsonObj, callback) => {
   return formatted.trim();
 }
 
+// 判断是否弹出层全屏
+export const setModalSizeEvent = (callback) => {
+  callback({isFull: window.screen.width < 768, width: window.screen.width})
+}
 // 加载远程js
 export const loadScript = (src, callback) => {  
   const s = document.createElement('script')


### PR DESCRIPTION
优化form-modal组件
curd弹出层表单，以及form-mdal弹出层表单，当设备屏幕小于768时设置弹出层全屏
增加 ma-info组件信息属性支持
支持函数事件回调注册 formModalRef.value.onSubmit((res) => {

})
增加 getAttr获取表单数据方法