### PR TITLE
feat(i18n): 重构i18n初始化与翻译调用方式

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "sortablejs": "1.15.6",
     "vaul-vue": "^0.3.0",
     "vue": "^3.5.32",
-    "vue-i18n": "11.1.2",
+    "vue-i18n": "^11.4.5",
     "vue-m-message": "^4.0.2",
     "vue-router": "^4.6.4",
     "vue3-sfc-loader": "^0.9.5",

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -12,11 +12,10 @@ import type { ProviderService } from '#/global'
 import type { App, Directive } from 'vue'
 import * as directives from '@/directives'
 import useThemeColor from '@/hooks/useThemeColor'
+import { setupI18n } from '@/i18n'
 import useTabStore from '@/store/modules/useTabStore.ts'
 import toolbars from '@/utils/toolbars.ts'
-import messages from '@intlify/unplugin-vue-i18n/messages'
 import ElementPlus from 'element-plus'
-import { createI18n } from 'vue-i18n'
 import router from './router'
 import pinia from './store'
 import './utils/copyright.ts'
@@ -41,31 +40,6 @@ import 'vue-m-message/dist/style.css'
 import '@/assets/styles/resources/variables.scss'
 import '@/assets/styles/resources/utils.scss'
 import '@/assets/styles/resources/element.scss'
-
-async function createI18nService(app: App) {
-  const locales: any[] = Object.entries(import.meta.glob('./locales/*.y(a)?ml')).map(([key]: any) => {
-    const [, value, label] = key.match(/^.\/locales\/(\w+)\[([^[\]]+)\]\.yaml$/)
-    return { label, value }
-  })
-  useUserStore().setLocales(locales)
-  Object.keys(messages as any).map((name: string) => {
-    const matchValue = name.match(/(\w+)/) as RegExpMatchArray | null
-    if (messages && matchValue) {
-      messages[matchValue[1]] = messages[name]
-      delete messages[name]
-    }
-  })
-
-  app.use(createI18n({
-    legacy: false,
-    globalInjection: true,
-    fallbackLocale: 'zh_CN',
-    locale: useUserStore().getLanguage(),
-    silentTranslationWarn: true,
-    silentFallbackWarn: true,
-    messages,
-  }))
-}
 
 async function initProvider(app: App) {
   const pvs = import.meta.glob('./provider/**/index.ts')
@@ -117,7 +91,7 @@ async function bootstrap(app: App): Promise<void> {
   app.use(ElementPlus, {})
   registerDirectives(app)
   await otherWorker(app)
-  await createI18nService(app)
+  setupI18n(app)
   await usePluginStore().registerPlugin(app)
   await router.isReady()
   useThemeColor().initThemeColor()

--- a/src/components/ma-city-select/index.vue
+++ b/src/components/ma-city-select/index.vue
@@ -24,7 +24,6 @@ zh_TW:
 <script setup lang="ts">
 import jsonData from './lib/cn.json'
 import type { Area, ModelType } from './type.ts'
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 
 defineOptions({ name: 'MaCitySelect' })
 
@@ -33,7 +32,7 @@ const { mode = 'name', showLevel = 3 } = defineProps<{
   showLevel: 1 | 2 | 3
 }>()
 
-const t = useLocalTrans()
+const { localTrans: t } = useTrans()
 const model = defineModel<ModelType>({ province: undefined, city: undefined, area: undefined})
 const province = ref<Area>([])
 const city = ref<Area>([])

--- a/src/components/ma-dialog/index.vue
+++ b/src/components/ma-dialog/index.vue
@@ -115,7 +115,7 @@ onMounted(() => {
     </template>
     <template #footer>
       <slot name="footerBefore" />
-      <slot v-if="$attrs.footer" name="footer">
+      <slot v-if="$attrs.footer || $attrs.footer !== false" name="footer">
         <el-button type="primary" :loading="okLoading" @click="ok">
           {{ $attrs?.okText ?? `${t('crud.ok')} Ctrl + Enter` }}
         </el-button>

--- a/src/components/ma-drawer/index.vue
+++ b/src/components/ma-drawer/index.vue
@@ -77,7 +77,7 @@ watch(() => keys.value, async () => {
     </template>
     <template #footer>
       <slot name="footerBefore" />
-      <slot v-if="$attrs.footer" name="footer">
+      <slot v-if="$attrs.footer || $attrs.footer !== false" name="footer">
         <el-button type="primary" :loading="okLoading" @click="ok">
           {{ $attrs?.okText ?? `${t('crud.ok')} Ctrl + Enter` }}
         </el-button>

--- a/src/components/ma-icon-picker/index.vue
+++ b/src/components/ma-icon-picker/index.vue
@@ -24,12 +24,12 @@ zh_TW:
 
 <script setup lang="ts">
 import MaIconPanel from './ma-icon-panel.vue'
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 
 defineOptions({ name: 'MaIconPicker' })
 
 const model = defineModel<string>()
 const iconPanelRef = ref()
+const { localTrans: t } = useTrans()
 
 const dialogVisible = ref<boolean>(false)
 </script>
@@ -41,14 +41,14 @@ const dialogVisible = ref<boolean>(false)
         v-model="model"
         class="relative w-full"
         readonly
-        :placeholder="useLocalTrans('showInputPlaceholder')"
+        :placeholder="t('showInputPlaceholder')"
       >
         <template v-if="model" #prefix>
           <ma-svg-icon :name="model" :size="20" />
         </template>
         <template #suffix>
           <el-button type="primary" class="absolute right-0 rounded-none" @click.prevent="dialogVisible = true">
-            {{ useLocalTrans('selectedIcon') }}
+            {{ t('selectedIcon') }}
           </el-button>
         </template>
         <template #append>
@@ -58,13 +58,13 @@ const dialogVisible = ref<boolean>(false)
               iconPanelRef?.clear()
             }"
           >
-            {{ useLocalTrans('clear') }}
+            {{ t('clear') }}
           </el-button>
         </template>
       </el-input>
     </div>
 
-    <el-dialog v-model="dialogVisible" :title="useLocalTrans('selectedIcon')" width="800" append-to-body draggable destroy-on-close align-center>
+    <el-dialog v-model="dialogVisible" :title="t('selectedIcon')" width="800" append-to-body draggable destroy-on-close align-center>
       <MaIconPanel
         ref="iconPanelRef"
         @select="(icon: string) => {

--- a/src/components/ma-icon-picker/ma-icon-panel.vue
+++ b/src/components/ma-icon-picker/ma-icon-panel.vue
@@ -20,7 +20,6 @@ zh_TW:
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-vue'
 import type { TabPaneName } from 'element-plus'
 import data from '@/iconify/data.json'
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 
 defineOptions({ name: 'MaIconPanel' })
 
@@ -65,7 +64,7 @@ function appendCustomIcons() {
 // 将处理后的数据赋值回 data
 const updatedData = appendCustomIcons()
 
-const t = useLocalTrans()
+const { localTrans: t } = useTrans()
 
 function getIcons() {
   currentIconList.value = updatedData.filter((item: any) => item.prefix === currentName.value)[0].icons

--- a/src/components/ma-tree/index.vue
+++ b/src/components/ma-tree/index.vue
@@ -37,7 +37,6 @@ zh_TW:
 <script setup lang="ts">
 import { ElTree } from 'element-plus'
 import { get } from 'lodash-es'
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 
 defineOptions({ name: 'MaTree' })
 
@@ -45,7 +44,7 @@ const { treeKey = 'label' } = defineProps<{
   treeKey?: string
 }>()
 
-const t = useLocalTrans()
+const { localTrans: t } = useTrans()
 
 const filterText = ref<string>('')
 const treeRef = ref<InstanceType<typeof ElTree>>()

--- a/src/components/ma-upload-file/index.vue
+++ b/src/components/ma-upload-file/index.vue
@@ -17,7 +17,6 @@ zh_TW:
 </i18n>
 
 <script setup lang="tsx">
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 import type { UploadUserFile } from 'element-plus'
 import { isArray, uid } from 'radash'
 import { useMessage } from '@/hooks/useMessage.ts'
@@ -47,7 +46,7 @@ const emit = defineEmits<{
 
 const id = uid(5)
 const msg = useMessage()
-const t = useLocalTrans()
+const { localTrans: t } = useTrans()
 
 const fileList = ref<UploadUserFile[]>([])
 

--- a/src/components/ma-upload-image/index.vue
+++ b/src/components/ma-upload-image/index.vue
@@ -20,7 +20,6 @@ zh_TW:
 </i18n>
 
 <script setup lang="tsx">
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 import type { UploadUserFile } from 'element-plus'
 import { isArray, uid } from 'radash'
 import { useDebounceFn } from '@vueuse/core'
@@ -53,7 +52,7 @@ const emit = defineEmits<{
 
 const id = uid(5)
 const msg = useMessage()
-const t = useLocalTrans()
+const { localTrans: t } = useTrans()
 
 const uploadBtnRef = ref<HTMLElement>()
 const isOpenResource = ref<boolean>(false)

--- a/src/components/ma-verify-code/index.vue
+++ b/src/components/ma-verify-code/index.vue
@@ -20,7 +20,6 @@ en:
 </i18n>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n'
 import Message from 'vue-m-message'
 
 defineOptions({ name: 'MaVerifyCode' })
@@ -41,10 +40,7 @@ const props = withDefaults(
     showError: true,
   },
 )
-const { t } = useI18n({
-  inheritLocale: true,
-  useScope: 'local',
-})
+const { localTrans: t } = useTrans()
 const codeText = ref('')
 const el = ref()
 

--- a/src/hooks/auto-imports/useTrans.ts
+++ b/src/hooks/auto-imports/useTrans.ts
@@ -8,6 +8,8 @@
  * @Link   https://github.com/mineadmin
  */
 
+import { getCurrentInstance } from 'vue'
+import { globalComposer } from '@/i18n'
 import { useI18n } from 'vue-i18n'
 import type { ComposerTranslation } from 'vue-i18n'
 
@@ -16,20 +18,62 @@ export interface TransType {
   localTrans: ComposerTranslation
 }
 
-export function useTrans(key: any | null = null): TransType | string | any {
-  const global = useI18n()
-  const local = useI18n({
-    inheritLocale: true,
-    useScope: 'local',
-  })
+const localComposerMap = new WeakMap<object, any>()
+const localTransMap = new WeakMap<object, ComposerTranslation>()
 
+function translate(composer: any, key: any, args: any[]) {
+  if (typeof key !== 'string' || !composer.te(key)) {
+    return undefined
+  }
+
+  return composer.t(key, ...args)
+}
+
+const globalTrans = ((key: any, ...args: any[]) => {
+  return translate(globalComposer, key, args) ?? key
+}) as ComposerTranslation
+
+function getLocalComposer(instance: object) {
+  let composer = localComposerMap.get(instance)
+  if (!composer) {
+    composer = useI18n({
+      inheritLocale: true,
+      useScope: 'local',
+    })
+    localComposerMap.set(instance, composer)
+  }
+
+  return composer
+}
+
+function getLocalTrans(): ComposerTranslation {
+  const instance = getCurrentInstance()
+  if (!instance) {
+    return globalTrans
+  }
+
+  let translator = localTransMap.get(instance)
+  if (!translator) {
+    const localComposer = getLocalComposer(instance)
+    translator = ((key: any, ...args: any[]) => {
+      return translate(localComposer, key, args) ?? translate(globalComposer, key, args) ?? key
+    }) as ComposerTranslation
+    localTransMap.set(instance, translator)
+  }
+
+  return translator
+}
+
+export function useTrans(key: any | null = null): TransType | string | any {
   if (key === null) {
     return {
-      localTrans: local.t,
-      globalTrans: global.t,
+      globalTrans,
+      get localTrans() {
+        return getLocalTrans()
+      },
     }
   }
   else {
-    return global.te(key) ? global.t(key) : local.te(key) ? local.t(key) : key
+    return globalTrans(key)
   }
 }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,50 @@
+import type { App } from 'vue'
+import messages from '@intlify/unplugin-vue-i18n/messages'
+import { createI18n } from 'vue-i18n'
+
+type LocaleMessages = Record<string, any>
+
+function normalizeLocaleName(name: string): string {
+  const filename = name.split('/').pop()?.split('\\').pop() ?? name
+  return filename.match(/^(\w+)(?:\[[^[\]]+\])?(?:\.ya?ml)?$/)?.[1] ?? filename.match(/(\w+)/)?.[1] ?? name
+}
+
+function normalizeMessages(source: LocaleMessages): LocaleMessages {
+  return Object.entries(source).reduce((normalized, [name, message]) => {
+    normalized[normalizeLocaleName(name)] = message
+    return normalized
+  }, {} as LocaleMessages)
+}
+
+function resolveLocales() {
+  return Object.entries(import.meta.glob('../locales/*.y(a)?ml')).map(([key]: any) => {
+    const match = key.match(/^\.\.\/locales\/(\w+)\[([^[\]]+)\]\.ya?ml$/)
+    if (match) {
+      const [, value, label] = match
+      return { label, value }
+    }
+
+    const value = normalizeLocaleName(key)
+    return { label: value, value }
+  })
+}
+
+export const i18n = createI18n({
+  legacy: false,
+  globalInjection: true,
+  fallbackLocale: 'zh_CN',
+  locale: 'zh_CN',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: normalizeMessages(messages as LocaleMessages),
+})
+
+export const globalComposer = i18n.global
+
+export function setupI18n(app: App) {
+  const userStore = useUserStore()
+
+  globalComposer.locale.value = userStore.getLanguage() as any
+  userStore.setLocales(resolveLocales())
+  app.use(i18n)
+}

--- a/src/layouts/components/menu/index.tsx
+++ b/src/layouts/components/menu/index.tsx
@@ -36,11 +36,23 @@ export default defineComponent({
       return props.mode === 'horizontal' || (props.mode === 'vertical' && props.collapse)
     })
 
+    function isVisibleMenuItem(item: MineRoute.routeRecord) {
+      const meta = item.meta as (MineRoute.RouteMeta & { menu?: boolean }) | undefined
+      return meta?.type !== 'B' && (meta?.hidden !== true || meta?.subForceShow === true) && meta?.menu !== false
+    }
+
+    function hasVisibleChildren(item: MineRoute.routeRecord) {
+      return item.children?.some(child => isVisibleMenuItem(child)) ?? false
+    }
+
     // 解析传入的 menu 数据，并保存到 items 和 subMenus 对象中
     function initItems(menu: MenuProps['menu'], parentPaths: string[] = []) {
       menu.forEach((item) => {
+        if (!isVisibleMenuItem(item)) {
+          return
+        }
         const index = item.path ?? JSON.stringify(item)
-        if (item?.children && item?.children?.length > 0) {
+        if (hasVisibleChildren(item)) {
           const indexPath = [index]
           if (parentPaths.length > 0) {
             indexPath.push(...parentPaths)
@@ -50,7 +62,7 @@ export default defineComponent({
             indexPath,
             active: false,
           }
-          initItems(item.children, indexPath)
+          initItems(item.children ?? [], indexPath)
         }
         else {
           const indexPath = [index, ...parentPaths]
@@ -62,6 +74,9 @@ export default defineComponent({
           items.value[index] = {
             index,
             indexPath,
+          }
+          if (item?.children && item?.children?.length > 0) {
+            initItems(item.children, indexPath)
           }
         }
       })

--- a/src/layouts/components/menu/sub.tsx
+++ b/src/layouts/components/menu/sub.tsx
@@ -25,6 +25,11 @@ export default defineComponent({
     const subMenuRef = shallowRef<OverlayScrollbarsComponentRef>()
     const rootMenu = inject(rootMenuInjectionKey)!
 
+    function isVisibleMenuItem(item: MineRoute.routeRecord) {
+      const meta = item.meta as (MineRoute.RouteMeta & { menu?: boolean }) | undefined
+      return meta?.type !== 'B' && (meta?.hidden !== true || meta?.subForceShow === true) && meta?.menu !== false
+    }
+
     const opened = computed(() => {
       return rootMenu.openedMenus.includes(uniqueKey.at(-1)!)
     })
@@ -97,26 +102,7 @@ export default defineComponent({
     })
 
     const hasChildren = computed(() => {
-      let flag = true
-      if (menu.children) {
-        if (menu.children.every((item: any) => item.meta?.menu === false)) {
-          flag = false
-        }
-        let hiddenLen = 0
-        menu.children.map((item: any) => {
-          if (item.meta?.hidden === true) {
-            hiddenLen++
-          }
-        })
-
-        if (hiddenLen === menu.children.length) {
-          flag = false
-        }
-      }
-      else {
-        flag = false
-      }
-      return flag
+      return menu.children?.some(child => isVisibleMenuItem(child)) ?? false
     })
 
     function handleClick() {

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -109,16 +109,13 @@ export default defineComponent({
         )}
         { route.meta?.useDefaultLayout === false && (
           <div class="no-default-layout-container">
-            <RouterView class="router-view" v-else>
+            <RouterView class="router-view">
               {({ Component }) => (
                 <Transition name={appSetting.pageAnimate} mode="out-in">
                   <Component key={route.fullPath} />
                 </Transition>
               )}
             </RouterView>
-            <div class="mine-iframe-area" v-show={route.meta?.type === 'I'}>
-              <MineIframe />
-            </div>
           </div>
         )}
       </>

--- a/src/modules/base/views/permission/menu/menu-form.vue
+++ b/src/modules/base/views/permission/menu/menu-form.vue
@@ -53,7 +53,7 @@ function setData(data: Record<string, any>) {
     }
   })
 
-  form.value.dataType = data.id ? 'edit' : 'add';
+  form.value.dataType = data.id ? 'edit' : 'add'
 }
 
 const inputVisible = ref <Record<string, boolean>>({
@@ -228,6 +228,7 @@ const formItems = ref<MaFormItem[]>([
   },
   {
     label: () => t('baseMenuManage.useDefaultLayout.label'), prop: 'meta.useDefaultLayout',
+    show: (_, model) => model.meta.type === 'M',
     render: () => (
       <div class="w-full">
         <el-radio-group v-model={form.value.meta.useDefaultLayout}>

--- a/src/modules/base/views/uc/components/modify-info.vue
+++ b/src/modules/base/views/uc/components/modify-info.vue
@@ -26,7 +26,6 @@ zh_TW:
 </i18n>
 
 <script setup lang="ts">
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 import passwordForm from './password-form.vue'
 import userinfoForm from './userinfo-form.vue'
 import { useMessage } from '@/hooks/useMessage.ts'
@@ -40,11 +39,11 @@ const userinfoFormRef = ref()
 const passwordFormRef = ref()
 
 const userStore = useUserStore()
-const globalTrans = useTrans().globalTrans
+const { globalTrans, localTrans: t } = useTrans()
 
 const tabOptions = reactive([
-  { label: useLocalTrans('change.info'), value: 'userinfo' },
-  { label: useLocalTrans('change.password'), value: 'password' },
+  { label: t('change.info'), value: 'userinfo' },
+  { label: t('change.password'), value: 'password' },
 ])
 
 const state = reactive({
@@ -85,7 +84,7 @@ defineExpose({ openModal })
 <template>
   <m-modal
     v-model="state.isOpen"
-    :title="useLocalTrans(selected === 'info' ? 'change.info' : 'change.password')"
+    :title="t(selected === 'info' ? 'change.info' : 'change.password')"
     content-class="w-[450px] h-[380px]"
   >
     <m-tabs v-model="selected" :options="tabOptions" class="text-sm" />
@@ -105,7 +104,7 @@ defineExpose({ openModal })
           selected === 'userinfo' ? userinfoFormRef.submit() : passwordFormRef.submit()
         }"
       >
-        {{ useLocalTrans(selected === 'userinfo' ? 'change.info' : 'change.password') }}
+        {{ t(selected === 'userinfo' ? 'change.info' : 'change.password') }}
       </m-button>
     </template>
   </m-modal>

--- a/src/modules/base/views/uc/components/password-form.vue
+++ b/src/modules/base/views/uc/components/password-form.vue
@@ -41,14 +41,13 @@ zh_TW:
 </i18n>
 
 <script setup lang="ts">
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 import Message from 'vue-m-message'
 
 const emit = defineEmits<{
   (event: 'submit', value: any)
 }>()
 
-const t = useLocalTrans()
+const { localTrans: t } = useTrans()
 
 const form = reactive({
   old_password: '',
@@ -100,37 +99,37 @@ defineExpose({ submit })
   <form class="mine-form" @submit.prevent="submit">
     <div class="mine-form-item">
       <div class="mine-form-item-title">
-        {{ useLocalTrans('changeInfo.old_passwordLabel') }}
+        {{ t('changeInfo.old_passwordLabel') }}
       </div>
       <m-input
         v-model="form.old_password"
         type="password"
         name="old_password"
-        :placeholder="useLocalTrans('changeInfo.old_passwordPlaceholder')"
+        :placeholder="t('changeInfo.old_passwordPlaceholder')"
         @blur="easyValidate"
       />
     </div>
     <div class="mine-form-item">
       <div class="mine-form-item-title">
-        {{ useLocalTrans('changeInfo.new_passwordLabel') }}
+        {{ t('changeInfo.new_passwordLabel') }}
       </div>
       <m-input
         v-model="form.new_password"
         type="password"
         name="new_password"
-        :placeholder="useLocalTrans('changeInfo.new_passwordPlaceholder')"
+        :placeholder="t('changeInfo.new_passwordPlaceholder')"
         @blur="easyValidate"
       />
     </div>
     <div class="mine-form-item">
       <div class="mine-form-item-title">
-        {{ useLocalTrans('changeInfo.new_password_confirmationLabel') }}
+        {{ t('changeInfo.new_password_confirmationLabel') }}
       </div>
       <m-input
         v-model="form.new_password_confirmation"
         type="password"
         name="new_password_confirmation"
-        :placeholder="useLocalTrans('changeInfo.new_password_confirmationPlaceholder')"
+        :placeholder="t('changeInfo.new_password_confirmationPlaceholder')"
         @blur="easyValidate"
       />
     </div>

--- a/src/modules/base/views/uc/components/userinfo-form.vue
+++ b/src/modules/base/views/uc/components/userinfo-form.vue
@@ -29,13 +29,12 @@ zh_TW:
 </i18n>
 
 <script setup lang="ts">
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
-
 const emit = defineEmits<{
   (event: 'submit', value: any)
 }>()
 
 const userStore = useUserStore()
+const { localTrans: t } = useTrans()
 
 const form = reactive({
   nickname: userStore.getUserInfo().nickname,
@@ -53,21 +52,21 @@ defineExpose({ submit })
   <form class="mine-form" @submit.prevent="submit">
     <div class="mine-form-item">
       <div class="mine-form-item-title">
-        {{ useLocalTrans('changeInfo.nicknameLabel') }}
+        {{ t('changeInfo.nicknameLabel') }}
       </div>
       <m-input
         v-model="form.nickname"
         name="nickname"
-        :placeholder="useLocalTrans('changeInfo.nicknamePlaceholder')"
+        :placeholder="t('changeInfo.nicknamePlaceholder')"
       />
     </div>
     <div class="mine-form-item">
       <div class="mine-form-item-title">
-        {{ useLocalTrans('changeInfo.signedLabel') }}
+        {{ t('changeInfo.signedLabel') }}
       </div>
       <m-textarea
         v-model="form.signed"
-        :placeholder="useLocalTrans('changeInfo.signedPlaceholder')"
+        :placeholder="t('changeInfo.signedPlaceholder')"
       />
     </div>
   </form>

--- a/src/modules/base/views/uc/index.vue
+++ b/src/modules/base/views/uc/index.vue
@@ -68,7 +68,6 @@ zh_TW:
 </i18n>
 
 <script setup lang="ts">
-import { useLocalTrans } from '@/hooks/useLocalTrans'
 import UcContainer from './components/container.vue'
 import UcModifyInfo from './components/modify-info.vue'
 import UcTitle from './components/title.vue'
@@ -77,9 +76,10 @@ import { useMessage } from '@/hooks/useMessage.ts'
 const modalRef = ref()
 const selected = ref('profile')
 const userStore = useUserStore()
+const { globalTrans, localTrans: t } = useTrans()
 const tabOptions = reactive([
-  { label: useLocalTrans('profile'), value: 'profile' },
-  { label: useLocalTrans('setting'), value: 'setting' },
+  { label: t('profile'), value: 'profile' },
+  { label: t('setting'), value: 'setting' },
 ])
 
 const msg = useMessage()
@@ -90,16 +90,15 @@ const form = reactive({
 })
 
 const avatar = ref<string>(userStore.getUserInfo().avatar)
-const globalTrans = useTrans().globalTrans
 
 const showFields = reactive({
-  nickname: useLocalTrans('userinfo.nickname'),
-  username: useLocalTrans('userinfo.username'),
-  signed: useLocalTrans('userinfo.signed'),
-  email: useLocalTrans('userinfo.email'),
-  phone: useLocalTrans('userinfo.phone'),
-  login_ip: useLocalTrans('userinfo.loginIp'),
-  login_time: useLocalTrans('userinfo.loginTime'),
+  nickname: t('userinfo.nickname'),
+  username: t('userinfo.username'),
+  signed: t('userinfo.signed'),
+  email: t('userinfo.email'),
+  phone: t('userinfo.phone'),
+  login_ip: t('userinfo.loginIp'),
+  login_time: t('userinfo.loginTime'),
 })
 
 watch(avatar, async (val: string | undefined) => {
@@ -116,7 +115,7 @@ watch(avatar, async (val: string | undefined) => {
     <UcTitle>
       <template #extra>
         <m-button class="h-8" @click="() => modalRef.openModal() ">
-          {{ useLocalTrans('changeProfileOrPassword') }}
+          {{ t('changeProfileOrPassword') }}
         </m-button>
       </template>
     </UcTitle>
@@ -131,7 +130,7 @@ watch(avatar, async (val: string | undefined) => {
           <li class="!b-none">
             <div class="desc-item">
               <div class="desc-label">
-                {{ useLocalTrans('userinfo.avatar') }}
+                {{ t('userinfo.avatar') }}
               </div>
               <div class="desc-value">
                 <ma-upload-image v-model="avatar" />
@@ -156,17 +155,17 @@ watch(avatar, async (val: string | undefined) => {
           <li class="bg-gray-1 !b-none dark-bg-dark-5">
             <div class="desc-item">
               <div class="desc-label font-bold">
-                {{ useLocalTrans('explain') }}
+                {{ t('explain') }}
               </div>
               <div class="desc-value font-bold">
-                {{ useLocalTrans('action') }}
+                {{ t('action') }}
               </div>
             </div>
           </li>
           <li>
             <div class="desc-item">
               <div class="desc-label">
-                {{ useLocalTrans('whetherReceiveMsg') }}
+                {{ t('whetherReceiveMsg') }}
               </div>
               <div class="desc-value">
                 <!--                <m-switch v-model="form.isReceiveMsg" /> -->
@@ -176,7 +175,7 @@ watch(avatar, async (val: string | undefined) => {
           <li>
             <div class="desc-item">
               <div class="desc-label">
-                {{ useLocalTrans('whetherMultiDeviceLogin') }}
+                {{ t('whetherMultiDeviceLogin') }}
               </div>
               <div class="desc-value">
                 <!--                <m-switch v-model="form.multiDeviceLogin" /> -->

--- a/src/plugins/mine-admin/app-store/views/filter.vue
+++ b/src/plugins/mine-admin/app-store/views/filter.vue
@@ -79,7 +79,6 @@ en:
 <script setup lang="ts">
 import type { UploadRequestOptions } from 'element-plus'
 import { uploadLocalApp } from '../api/app.ts'
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 import { useThrottleFn } from '@vueuse/core'
 import { useMessage } from '@/hooks/useMessage.ts'
 
@@ -94,7 +93,7 @@ const msg = useMessage()
 const storeMeta = inject('storeMeta') as Record<string, any>
 const filterParams = inject('filterParams') as Record<string, any>
 const requestAppList = inject('requestAppList') as () => void
-const t = useLocalTrans()
+const { localTrans: t } = useTrans()
 const params = reactive({
   add_type: 'all',
   type: 'all',

--- a/src/plugins/mine-admin/app-store/views/index.vue
+++ b/src/plugins/mine-admin/app-store/views/index.vue
@@ -41,7 +41,6 @@ en:
 </i18n>
 
 <script setup lang="ts">
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 import { getAppList, getLocalAppInstallList, getPayApp, hasAccessToken } from '../api/app.ts'
 import AppStoreNotice from './notice.vue'
 import AppStoreFilter from './filter.vue'
@@ -51,7 +50,7 @@ import AppStoreLocalList from './localList.vue'
 defineOptions({ name: 'MineAppStoreRoute' })
 
 const tabStore = useTabStore()
-const t = useLocalTrans()
+const { localTrans: t } = useTrans()
 const noticeRef = ref()
 const appList = ref<any[]>()
 const storeMeta = ref<Record<string, any>>({

--- a/src/plugins/mine-admin/app-store/views/list.vue
+++ b/src/plugins/mine-admin/app-store/views/list.vue
@@ -24,7 +24,6 @@ en:
 
 <script setup lang="ts">
 import AppStoreDetail from './detail.vue'
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 import { useMessage } from '@/hooks/useMessage.ts'
 import discount from '../utils/discount.ts'
 import { isUndefined } from 'lodash-es'
@@ -32,7 +31,7 @@ import { isUndefined } from 'lodash-es'
 const storeMeta = inject('storeMeta') as Record<string, any>
 const dataList = inject('dataList') as Record<string, any>
 
-const t = useLocalTrans()
+const { localTrans: t } = useTrans()
 const msg = useMessage()
 const detailRef = ref()
 const route = useRoute()

--- a/src/plugins/mine-admin/app-store/views/localList.vue
+++ b/src/plugins/mine-admin/app-store/views/localList.vue
@@ -27,7 +27,7 @@ import type { MaTableExpose } from '@mineadmin/table'
 
 const tableRef = ref<MaTableExpose>()
 const dataList = inject('dataList') as Record<string, any>
-const t = useTrans().localTrans
+const { localTrans: t } = useTrans()
 
 nextTick(() => {
   const data = Object.keys(dataList.value.local).map((name) => {

--- a/src/plugins/mine-admin/app-store/views/notice.vue
+++ b/src/plugins/mine-admin/app-store/views/notice.vue
@@ -57,9 +57,8 @@ en:
 
 <script setup lang="ts">
 import useDialog from '@/hooks/useDialog.ts'
-import { useLocalTrans } from '@/hooks/useLocalTrans.ts'
 
-const t = useLocalTrans()
+const { localTrans: t } = useTrans()
 const { Dialog, open, close } = useDialog({
   title: t('title'),
   ok: () => close(),

--- a/src/utils/handleResize.ts
+++ b/src/utils/handleResize.ts
@@ -16,9 +16,21 @@ export default function handleResize(el: Ref<HTMLElement>) {
   const { setMobileState, setMobileSubmenuState } = useSettingStore()
   useResizeObserver(document.body, (entries) => {
     const [entry] = entries
+    if (!entry) {
+      return
+    }
+
     const { width, height } = entry.contentRect
-    const searchPanelNode = document.querySelector('.mine-search-panel-container') as HTMLElement
-    searchPanelNode.style.top = height < 500 ? '0px' : height < 800 ? 'calc(100% - 50% - 250px)' : 'calc(100% - 50% - 350px)'
+    const searchPanelNode = document.querySelector<HTMLElement>('.mine-search-panel-container')
+    let searchPanelTop = 'calc(100% - 50% - 350px)'
+    if (height < 500) {
+      searchPanelTop = '0px'
+    }
+    else if (height < 800) {
+      searchPanelTop = 'calc(100% - 50% - 250px)'
+    }
+
+    searchPanelNode?.style.setProperty('top', searchPanelTop)
     setMobileState(width < 1024)
     setMobileSubmenuState(!(width < 1024))
     checkMobileSubAside(el)
@@ -33,6 +45,10 @@ function checkMobileSubAside(el: Ref<HTMLElement>) {
   const { isOutside } = useMouseInElement(el)
   const settingStore = useSettingStore()
   const targetEl = el.value
+
+  if (!targetEl) {
+    return
+  }
 
   // 如果之前绑定过，先移除
   const prevListener = listenerMap.get(targetEl)


### PR DESCRIPTION
- 提取i18n初始化逻辑至setupI18n，升级vue-i18n版本
- 统一使用useTrans替换useLocalTrans和useI18n
- 修复菜单项可见性判断，隐藏无可见子项的目录
- 修复对话框/抽屉footer属性为false时的显示问题
- 增加resize处理空元素防护，移除冗余iframe区域
- 菜单表单中按类型显示默认布局选项

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **Bug 修复**
  * 修复对话框和抽屉组件的底部区域默认显示行为。
  * 改进菜单项可见性过滤逻辑，优化菜单显示效果。

* **优化改进**
  * 增强表单字段显示条件控制。
  * 优化 DOM 操作的空值检查，提高应用稳定性。

* **依赖更新**
  * 更新 vue-i18n 至 ^11.4.5。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->